### PR TITLE
method JobExecution.to_dict() is corrected

### DIFF
--- a/SpiderKeeper/app/blueprints/dashboard/api.py
+++ b/SpiderKeeper/app/blueprints/dashboard/api.py
@@ -413,12 +413,25 @@ class JobExecutionDetailCtrl(flask_restful.Resource):
                 "required": True,
                 "paramType": "path",
                 "dataType": 'string'
+            },
+            {
+                "name": "signal",
+                "description": "signal",
+                "required": False,
+                "paramType": "form",
+                "dataType": 'string'
             }
         ])
     def put(self, project_id, job_exec_id):
+        post_data = request.form
+        if post_data:
+            signal =  post_data.get('signal')
+        else: 
+            signal = None
+                            
         job_execution = JobExecution.query.filter_by(project_id=project_id, id=job_exec_id).first()
         if job_execution:
-            agent.cancel_spider(job_execution)
+            agent.cancel_spider(job_execution, signal=signal)
             return True
 
 api.add_resource(JobExecutionDetailCtrl, "/api/projects/<project_id>/jobexecs/<job_exec_id>")

--- a/SpiderKeeper/app/blueprints/dashboard/model.py
+++ b/SpiderKeeper/app/blueprints/dashboard/model.py
@@ -176,7 +176,7 @@ class JobExecution(Base):
             'end_time': self.end_time.strftime('%Y-%m-%d %H:%M:%S') if self.end_time else None,
             'running_status': self.running_status,
             'running_on': self.running_on,
-            'job_instance': self.job_instance.to_dict(), #self job_instance is not serializable
+            'job_instance': self.job_instance.to_dict() if self.job_instance else None, #self job_instance is not serializable
             'has_warnings': self.has_warnings(),
             'has_errors': self.has_errors(),
             'items_count': self.items_count if self.items_count is not None else '-',

--- a/SpiderKeeper/app/blueprints/dashboard/model.py
+++ b/SpiderKeeper/app/blueprints/dashboard/model.py
@@ -176,7 +176,7 @@ class JobExecution(Base):
             'end_time': self.end_time.strftime('%Y-%m-%d %H:%M:%S') if self.end_time else None,
             'running_status': self.running_status,
             'running_on': self.running_on,
-            'job_instance': self.job_instance,
+            'job_instance': self.job_instance.to_dict(), #self job_instance is not serializable
             'has_warnings': self.has_warnings(),
             'has_errors': self.has_errors(),
             'items_count': self.items_count if self.items_count is not None else '-',

--- a/SpiderKeeper/app/blueprints/dashboard/views.py
+++ b/SpiderKeeper/app/blueprints/dashboard/views.py
@@ -214,7 +214,7 @@ def spider_dashboard(project_id):
         spider.last_runtime = last_runtime.get(spider.spider_name)
         if avg_runtime.get(spider.spider_name) is not None:
             spider.avg_runtime = str(datetime.timedelta(
-                hours=avg_runtime.get(spider.spider_name)
+                days=avg_runtime.get(spider.spider_name)
                 )
             )
         spiders.append(spider)

--- a/SpiderKeeper/app/proxy/contrib/scrapy.py
+++ b/SpiderKeeper/app/proxy/contrib/scrapy.py
@@ -83,10 +83,13 @@ class ScrapydProxy(SpiderServiceProxy):
     def cancel_spider(self, project_name, job_id, signal=None):
         post_data = dict(
             project=project_name, 
-            job=job_id
+            job=job_id,
+            signal='KILL'
         )
+        '''
         if signal is not None:
             post_data['signal'] = signal
+        '''
         data = request(
             "post", self._scrapyd_url() + "/cancel.json", data=post_data, return_type="json"
         )

--- a/SpiderKeeper/app/proxy/contrib/scrapy.py
+++ b/SpiderKeeper/app/proxy/contrib/scrapy.py
@@ -80,8 +80,13 @@ class ScrapydProxy(SpiderServiceProxy):
         )
         return data['jobid'] if data and data['status'] == 'ok' else None
 
-    def cancel_spider(self, project_name, job_id):
-        post_data = dict(project=project_name, job=job_id)
+    def cancel_spider(self, project_name, job_id, signal=None):
+        post_data = dict(
+            project=project_name, 
+            job=job_id
+        )
+        if signal is not None:
+            post_data['signal'] = signal
         data = request(
             "post", self._scrapyd_url() + "/cancel.json", data=post_data, return_type="json"
         )

--- a/SpiderKeeper/app/proxy/spiderctrl.py
+++ b/SpiderKeeper/app/proxy/spiderctrl.py
@@ -163,12 +163,12 @@ class SpiderAgent(object):
             db.session.add(job_execution)
             db.session.commit()
 
-    def cancel_spider(self, job_execution):
+    def cancel_spider(self, job_execution, signal=None):
         job_instance = JobInstance.query.get(job_execution.job_instance_id)
         project = Project.query.get(job_instance.project_id)
         for spider_service_instance in self.spider_service_instances:
             if spider_service_instance.server == job_execution.running_on:
-                if spider_service_instance.cancel_spider(project.project_name, job_execution.service_job_execution_id):
+                if spider_service_instance.cancel_spider(project.project_name, job_execution.service_job_execution_id, signal=signal):
                     job_execution.end_time = datetime.datetime.now()
                     job_execution.running_status = SpiderStatus.CANCELED
                     db.session.commit()

--- a/SpiderKeeper/app/templates/spider_dashboard.html
+++ b/SpiderKeeper/app/templates/spider_dashboard.html
@@ -20,7 +20,7 @@
                 <td>{{ spider.id }}</td>
                 <td>{{ spider.spider_name }}</td>
                 <td>{{ spider.last_runtime if spider.last_runtime else '-' }}</td>
-                <td>{{ readable_time(spider.avg_runtime) }}</td>
+                <td>{{ spider.avg_runtime if spider.avg_runtime else '-'}}</td>
             </tr>
             {% endfor %}
         </table>


### PR DESCRIPTION
When a I use a SpiderKeeper API 

http://0.0.0.0:5000/api/projects/1/jobexecs
 
i see this problem:
{
  "code": 500,
  "data": null,
  "msg": "Object of type JobInstance is not JSON serializable",
  "success": false
}
